### PR TITLE
Throw warnings instead of errors regarding vendor extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 docs/
 *.gem
-*.gemspec
+#*.gemspec

--- a/lib/w3c_validators/css_validator.rb
+++ b/lib/w3c_validators/css_validator.rb
@@ -89,7 +89,7 @@ module W3CValidators
 protected
     def validate(options) # :nodoc:
       options = get_request_options(options)
-      response = send_request(options, :get)
+      response = send_request(options, :post)
       @results = parse_soap_response(response.body)
       @results
     end

--- a/lib/w3c_validators/css_validator.rb
+++ b/lib/w3c_validators/css_validator.rb
@@ -5,7 +5,7 @@ module W3CValidators
     # Create a new instance of the CSSValidator.
     #
     # ==== Options
-    # You can pass in your own validator's URI (i.e. 
+    # You can pass in your own validator's URI (i.e.
     # <tt>CSSValidator.new(:validator_uri => 'http://localhost/check')</tt>).
     #
     # See Validator#new for proxy server options.
@@ -19,7 +19,7 @@ module W3CValidators
       options[:profile] ||= 'css3'
       super(options)
     end
-    
+
     # The CSS profile used for the validation.
     #
     # +charset+ can be a string or a symbl from the W3CValidators::CSS_PROFILES hash.
@@ -51,6 +51,11 @@ module W3CValidators
       @options[:lang] = lang
     end
 
+    # Throw warnings instead of errors regarding vendor extensions
+    def vendor_extensions_as_warnings!
+      @options[:vextwarning] = true
+    end
+
     # Validate the CSS of an URI.
     #
     # Returns W3CValidators::Results.
@@ -64,7 +69,7 @@ module W3CValidators
     def validate_text(text)
       return validate({:text => text})
     end
-    
+
     # Validate the CSS of a local file.
     #
     # +file_path+ may be either the fully-expanded path to the file or
@@ -76,7 +81,7 @@ module W3CValidators
         src = file_path.read
       else
         src = read_local_file(file_path)
-      end 
+      end
       return validate_text(src)
     end
 
@@ -92,9 +97,9 @@ protected
     # Perform sanity checks on request params
     def get_request_options(options) # :nodoc:
       options = @options.merge(options)
-     
+
       options[:output] = SOAP_OUTPUT_PARAM
-      
+
       unless options[:uri] or options[:text]
         raise ArgumentError, "an uri or text is required."
       end
@@ -111,11 +116,11 @@ protected
 
     def parse_soap_response(response) # :nodoc:
       doc = Nokogiri::XML(response)
-      doc.remove_namespaces! 
+      doc.remove_namespaces!
 
       result_params = {}
 
-      {:uri => 'uri', :checked_by => 'checkedby', :validity => 'validity', :css_level => 'csslevel'}.each do |local_key, remote_key|        
+      {:uri => 'uri', :checked_by => 'checkedby', :validity => 'validity', :css_level => 'csslevel'}.each do |local_key, remote_key|
         if val = doc.at('cssvalidationresponse ' + remote_key)
           result_params[local_key] = val.text
         end
@@ -124,7 +129,7 @@ protected
       results = Results.new(result_params)
 
       ['warninglist', 'errorlist'].each do |list_type|
-        doc.css(list_type).each do |message_list|        
+        doc.css(list_type).each do |message_list|
 
           if uri_node = message_list.at('uri')
             uri = uri_node.text
@@ -148,6 +153,6 @@ protected
       handle_exception e
     end
 
-  
+
   end
 end

--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -59,6 +59,9 @@ module W3CValidators
             # send a GET request
             query = create_query_string_data(options)          
             response = http.get(@validator_uri.path + '?' + query)
+
+            # Fix for enabled Net::HTTP.version_1_1
+            response = response.first if response.is_a?(Array)
           when :post
             # send a multipart form request
             if params_to_post

--- a/test/test_css_validator.rb
+++ b/test/test_css_validator.rb
@@ -9,7 +9,6 @@ class CSSValidatorTests < Test::Unit::TestCase
     @invalid_fragment = <<-EOT
     a { color: white; }
     body { margin: blue; }
-    
     EOT
 
     sleep 1
@@ -32,7 +31,7 @@ class CSSValidatorTests < Test::Unit::TestCase
     r = @v.validate_text(@invalid_fragment)
     assert_errors r, 1
   end
- 
+
   def test_validating_text
     r = @v.validate_text(@invalid_fragment)
     assert_errors r, 1
@@ -40,12 +39,17 @@ class CSSValidatorTests < Test::Unit::TestCase
 
   def test_validating_text_via_file
     file_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/invalid_css.css')
-    fh = File.new(file_path, 'r+')    
+    fh = File.new(file_path, 'r+')
     r = @v.validate_file(fh)
     fh.close
     assert_errors r, 1
   end
 
+  def test_disabling_of_vendor_extension_errors
+    @v.vendor_extensions_as_warnings!
+    r = @v.validate_text("p { -moz-border-radius: 5px; }")
+    assert_errors r, 0
+    assert_warnings r, 1
+  end
 
- 
 end

--- a/w3c_validators.gemspec
+++ b/w3c_validators.gemspec
@@ -1,0 +1,20 @@
+# Auto-generated gemspec
+# Run 'rake generate_gemspec' to re-generate
+Gem::Specification.new do |s|
+  s.name     = "w3c_validators"
+  s.platform = Gem::Platform::RUBY
+  s.version  = "1.2.1.pre"
+  s.date     = "2011-11-22"
+  s.summary  = "Wrapper for the World Wide Web Consortium's online validation services."
+  s.email    = "code@dunae.ca"
+  s.homepage = "http://code.dunae.ca/w3c_validators"
+  s.description = "W3C Validators is a Ruby wrapper for the World Wide Web Consortium's online validation services."
+  s.has_rdoc = true
+  s.author  = "Alex Dunae"
+  s.add_runtime_dependency 'nokogiri'
+  s.add_runtime_dependency 'json'
+  s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG', 'LICENSE']
+  s.rdoc_options << '--all' << '--inline-source' << '--line-numbers' << '--charset' << 'utf-8'
+  s.test_files = ['test/test_css_validator.rb','test/test_exceptions.rb','test/test_feed_validator.rb','test/test_helper.rb','test/test_html5_validator.rb','test/test_markup_validator.rb','test/test_proxy.rb']
+  s.files = ['lib/w3c_validators','lib/w3c_validators/constants.rb','lib/w3c_validators/css_validator.rb','lib/w3c_validators/exceptions.rb','lib/w3c_validators/feed_validator.rb','lib/w3c_validators/markup_validator.rb','lib/w3c_validators/message.rb','lib/w3c_validators/nu_validator.rb','lib/w3c_validators/results.rb','lib/w3c_validators/validator.rb','lib/w3c_validators.rb']
+end


### PR DESCRIPTION
The method CSSValidator.new#vendor_extensions_as_warnings! tells the validator to throw warnings insted of errors on vendor extensions.

Closes #7.
