### PR TITLE
adds context and skippedstring to CSS messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 docs/
 *.gem
-*.gemspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docs/
 *.gem
+.ruby-version
+.ruby-gemset

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,3 +30,8 @@
 == Version 1.1
  * Ruby 1.9 compatibility
  * Switched to Nokogiri for XML parsing
+ 
+== Version 1.2
+ * Use CSS3 as default profile 
+ * Use Bundler and update to new RDoc command 
+ * Use POST in feed validator

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'nokogiri'
-gem 'json'
-
-group :documentation do
-  gem 'rdoc'
-end
-
-group :debug do
-  gem 'ruby-debug19', :require => 'ruby-debug', :platforms => :ruby_19
-  gem 'ruby-debug', :platforms => :ruby_18
-end
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'nokogiri'

--- a/lib/w3c_validators/message.rb
+++ b/lib/w3c_validators/message.rb
@@ -1,7 +1,7 @@
 module W3CValidators
   class Message
     attr_accessor :type, :line, :col, :source, :explanation, :message, :message_id
-    attr_accessor :message_count, :element, :parent, :value
+    attr_accessor :message_count, :element, :parent, :value, :context, :skippedstring
     
     MESSAGE_TYPES = [:warning, :error]
 
@@ -31,6 +31,8 @@ module W3CValidators
     # * +level+
     # * +line+
     # * +message+
+    # * +context+
+    # * +skippedstring+
     # See http://jigsaw.w3.org/css-validator/api.html#soap12message for full explanations.
     def initialize(uri, message_type, options = {})
       @type = message_type
@@ -54,7 +56,9 @@ module W3CValidators
       @value = options[:value]
 
       # CSSValidator
-      @level = options[:level]
+      @level          = options[:level]
+      @context        = options[:context].strip       if options[:context]
+      @skippedstring  = options[:skippedstring].strip if options[:skippedstring]
     end
 
     def is_warning?

--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -12,7 +12,7 @@ require 'w3c_validators/message'
 module W3CValidators
   # Base class for MarkupValidator and FeedValidator.
   class Validator
-    VERSION                   = '1.1'
+    VERSION                   = '1.2'
     USER_AGENT                = "Ruby W3C Validators/#{Validator::VERSION} (http://code.dunae.ca/w3c_validators/)"
     HEAD_STATUS_HEADER        = 'X-W3C-Validator-Status'
     HEAD_ERROR_COUNT_HEADER   = 'X-W3C-Validator-Errors'

--- a/lib/w3c_validators/validator.rb
+++ b/lib/w3c_validators/validator.rb
@@ -12,7 +12,6 @@ require 'w3c_validators/message'
 module W3CValidators
   # Base class for MarkupValidator and FeedValidator.
   class Validator
-    VERSION                   = '1.2'
     USER_AGENT                = "Ruby W3C Validators/#{Validator::VERSION} (http://code.dunae.ca/w3c_validators/)"
     HEAD_STATUS_HEADER        = 'X-W3C-Validator-Status'
     HEAD_ERROR_COUNT_HEADER   = 'X-W3C-Validator-Errors'

--- a/lib/w3c_validators/version.rb
+++ b/lib/w3c_validators/version.rb
@@ -1,0 +1,3 @@
+module W3CValidators
+  VERSION = "1.2"
+end

--- a/test/test_css_validator.rb
+++ b/test/test_css_validator.rb
@@ -46,6 +46,16 @@ class CSSValidatorTests < Test::Unit::TestCase
     assert_errors r, 1
   end
 
+  def test_context
+    file_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/invalid_css.css')
+    results = @v.validate_file(file_path)
+    assert results.errors.first.context == "body"
+  end
 
+  def test_skippedstring
+    file_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/invalid_css.css')
+    results = @v.validate_file(file_path)
+    assert results.errors.first.skippedstring == "blue"
+  end
  
 end

--- a/w3c_validators.gemspec
+++ b/w3c_validators.gemspec
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/w3c_validators.rb', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Alex Dunae"]
+  gem.summary       = "A Ruby wrapper for the World Wide Web Consortium’s online validation services."
+  gem.homepage      = "https://github.com/alexdunae/w3c_validators"
+
+  gem.files         = `git ls-files`.split("\n")
+  gem.test_files    = `git ls-files -- {test}/*`.split("\n")
+  gem.name          = "w3c_validators"
+  gem.require_paths = ["lib"]
+  gem.version       = W3CValidators::Validator::VERSION
+
+  gem.add_dependency 'nokogiri'
+end

--- a/w3c_validators.gemspec
+++ b/w3c_validators.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/w3c_validators.rb', __FILE__)
+require File.expand_path('../lib/w3c_validators/version.rb', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Alex Dunae"]
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test}/*`.split("\n")
   gem.name          = "w3c_validators"
   gem.require_paths = ["lib"]
-  gem.version       = W3CValidators::Validator::VERSION
+  gem.version       = W3CValidators::VERSION
 
   gem.add_dependency 'nokogiri', '~> 1.6'
   gem.add_dependency 'json'

--- a/w3c_validators.gemspec
+++ b/w3c_validators.gemspec
@@ -12,5 +12,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = W3CValidators::Validator::VERSION
 
-  gem.add_dependency 'nokogiri'
+  gem.add_dependency 'nokogiri', '~> 1.6'
+  gem.add_dependency 'json'
+
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rdoc'
+  gem.add_development_dependency 'ruby-debug19'
 end


### PR DESCRIPTION
Although it does not appear on the documentation, the validation response for CSS includes the `context` and `skippedstring` properties, like this:

```
<m:error>
    <m:line>2</m:line>
    <m:errortype>parse-error</m:errortype>
    <m:context> audio, canvas, video </m:context>        
    <m:errorsubtype>
        unrecognized
    </m:errorsubtype>
    <m:skippedstring>
        ;*display:inline;
    </m:skippedstring>

    <m:message>
            Error de análisis sintáctico
    </m:message>
</m:error>
```

This commit adds the ability to parse these properties from the response.
