### PR TITLE
fix missing require of version

### DIFF
--- a/lib/w3c_validators.rb
+++ b/lib/w3c_validators.rb
@@ -1,4 +1,5 @@
 $:.unshift File.dirname(__FILE__)
+require 'w3c_validators/version'
 require 'w3c_validators/validator'
 require 'w3c_validators/markup_validator'
 require 'w3c_validators/nu_validator'


### PR DESCRIPTION
Without this fix `require 'w3c_validators'`leads to the following error:

`NameError: uninitialized constant W3CValidators::Validator::VERSION`
